### PR TITLE
Add no_proxy variable to not use proxy for internal IPs

### DIFF
--- a/none.yaml
+++ b/none.yaml
@@ -120,8 +120,10 @@ resources:
             rm /var/lib/apt/lists/lock
             export http_proxy=$proxy
             export https_proxy=$proxy
+            export no_proxy=127.0.0.1,localhost,10,192.168
             echo "export http_proxy=$proxy" >> /etc/profile.d/proxy.sh
             echo "export https_proxy=$proxy" >> /etc/profile.d/proxy.sh
+            echo "export no_proxy=127.0.0.1,localhost,10,192.168" >> /etc/profile.d/proxy.sh
 
             # Update sources.list based on bootImage
             if [ $bootImage = "Ubuntu1604" ]


### PR DESCRIPTION
This stops using http_proxy for private IPs in the range 10/8 & 
192.168/24